### PR TITLE
Firefox get premission at install (manifest v3)

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,3 +1,14 @@
+chrome.runtime.onInstalled.addListener((details) => { // run at install
+    //tartalmazza e ezeket a permissionoket
+    chrome.permissions.contains({'origins':
+        // az oszes manifestben levo premission ami vebhejre mutat
+        chrome.runtime.getManifest()['host_permissions']},(answer) => {
+            if (! answer){ // ha nem tartalmazza => open a new tab ahol premissionoket kerunk a usertol
+                chrome.tabs.create({"url":chrome.runtime.getURL("premissions.html")});
+            }
+    });
+});
+
 const MATweaksVersion = chrome.runtime.getManifest().version;
 class Settings {
     constructor() {

--- a/src/premissions.html
+++ b/src/premissions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Premissions</title><link rel="icon" href="logo/MATLogo-128.png">
+</head>
+<body>
+<h1>Egyes böngészőkőn manuálisan kell megadni a jogokat hogy fusson a <br/>
+<img src="logo/MATLogo-128.png" style="height:1em;"> MagyarAnimeTweaks</h1>
+<button id="grant-premissions">Jogok megadása</button>
+<script src="premissions.js"></script>
+</body></html>

--- a/src/premissions.js
+++ b/src/premissions.js
@@ -1,0 +1,3 @@
+document.querySelector("#grant-premissions").addEventListener("click",(details) => { // add a click event to the element where id="grant-premissions"
+    chrome.permissions.request({"origins":chrome.runtime.getManifest()['host_permissions']}); // on click request all website premissions (browser will only ask the user what is not granted)
+});


### PR DESCRIPTION
ez az egyik megoldása annak hogy az extension kérjen magának jogokat amikor installálod.
a másik megoldás az az hogy a manifest.json -t átrakod a firefox -nál v2 -be mert ott megadja automatán nem kell magadnak elkérned.

azt csinálja a modositásom, hogy minden installáláskor, megnézi hogy meg van e adva az oszes jog a kiegészitönek, és ha nincs megnyit egy uj lapot ahol egy gombnyomással el lehet fogadni az oszes jogot.
a html file nagyon base, a hejesirásom is csapni valo, mindenesetre remélem legalább, egy otletet adhattok hogyan kéne megoldani a jog kérést.